### PR TITLE
New version of JsonSlurper seems to use LazyMap under the hood. LazyM…

### DIFF
--- a/src/cloudfoundry.groovy
+++ b/src/cloudfoundry.groovy
@@ -1,4 +1,4 @@
-import groovy.json.JsonSlurper
+import groovy.json.JsonSlurperClassic
 
 def getShell() {
     new shell()
@@ -70,7 +70,7 @@ def getDomains(cfSpace, cfOrg, cfApiEndpoint) {
 def parseJson(url, cfApiEndpoint) {
     authenticate(cfApiEndpoint) {
         def contents = getShell().pipe("cf curl \"${url}\"") as String
-        new JsonSlurper().parseText(contents)
+        new JsonSlurperClassic().parseText(contents)
     }
 }
 


### PR DESCRIPTION
…ap causes Serialisation failures. Switch to JsonSlurperClassic to maintain original behaviour